### PR TITLE
auto-backup-v1

### DIFF
--- a/SaveManager.py
+++ b/SaveManager.py
@@ -248,7 +248,9 @@ def new_character():
             input("")
 
 def auto_save(display_prompt=True):
+    print("\n\tAuto-saving...")
     global last_backup_timestamp
+    print(f"DEBUG: Last backup timestamp: {last_backup_timestamp}")
 
     if (display_prompt):
         user_input= input("\n\tDo you want to back up your current save? [Y/N]: ")
@@ -256,19 +258,23 @@ def auto_save(display_prompt=True):
         if (user_input.lower() != "y"):
             return
         
+    print("\n\tCreating backup...")
     current_save_directory = os.path.join(save_path, 'remote', 'win64_save')
-    current_save_timestamp = get_latest_save_timestamp(current_save_directory)
+    current_save_timestamp = get_latest_backup_timestamp(current_save_directory)
+    print(f"DEBUG: Current save timestamp: {current_save_timestamp}")
 
     if current_save_timestamp == last_backup_timestamp:
         if (display_prompt):
             promptEnter("No changes detected since last backup. Backup aborted.")
-        # print("DEBUG: No changes detected since last backup. Backup aborted.")
+        print("DEBUG: No changes detected since last backup. Backup aborted.")
         return
     elif last_backup_timestamp is None or current_save_timestamp > last_backup_timestamp:
         last_backup_timestamp = current_save_timestamp
 
     # this will remove any excess backups if the max backups is set
+    print("DEBUG: Managing backups...")
     manage_backups()
+    print("DEBUG: Backups managed.")
     
     random_string = "_"+generate_random_string()
     save_name = "BackupSave" + random_string
@@ -284,7 +290,7 @@ def auto_save(display_prompt=True):
             destination_file = os.path.join("Characters/"+current_character+"/"+save_name, filename)
             shutil.copy(source_file, destination_file)
 
-    # print(f"DEBUG: Backup created at {current_save_timestamp}")
+    print(f"DEBUG: Backup created at {current_save_timestamp}")
 
 def save_game():
 
@@ -335,7 +341,7 @@ def save_game():
 
     promptEnter()
     
-def get_latest_save_timestamp(save_directory):
+def get_latest_backup_timestamp(save_directory):
     """Get the timestamp of the latest modified file in the save directory."""
     save_files = os.listdir(save_directory)
     if not save_files:
@@ -474,7 +480,7 @@ def auto_backup():
         return
     
     current_save_directory = os.path.join(save_path, 'remote', 'win64_save')
-    last_backup_timestamp = get_latest_save_timestamp(current_save_directory)
+    last_backup_timestamp = get_latest_backup_timestamp(current_save_directory)
     
     print("Note: Save Data can be around 10mb per save. 10 saves = 100mb. 100 saves = 1gb.")
     print("Note: Please be aware of the space on your drive.")
@@ -542,7 +548,7 @@ def backup_timer(interval):
 
     # Calculate the interval in seconds
     interval_seconds = interval * 60   # Convert interval to seconds
-    # interval_seconds = 5 # debug interval
+    interval_seconds = 5 # debug interval
 
     next_backup_time = time.time() + interval_seconds  # Schedule the first backup
 
@@ -551,7 +557,9 @@ def backup_timer(interval):
         current_time = time.time()
 
         if current_time >= next_backup_time:
+            print("DEBUG: Auto backup triggered.")
             with backup_lock:
+                print("DEBUG: Auto backup lock acquired.")
                 if not backup_active:  # Double-check if the backup is still active
                     break
                 auto_save(display_prompt=False)

--- a/SaveManager.py
+++ b/SaveManager.py
@@ -250,7 +250,6 @@ def new_character():
 def auto_save(display_prompt=True):
     print("\n\tAuto-saving...")
     global last_backup_timestamp
-    print(f"DEBUG: Last backup timestamp: {last_backup_timestamp}")
 
     if (display_prompt):
         user_input= input("\n\tDo you want to back up your current save? [Y/N]: ")
@@ -261,20 +260,17 @@ def auto_save(display_prompt=True):
     print("\n\tCreating backup...")
     current_save_directory = os.path.join(save_path, 'remote', 'win64_save')
     current_save_timestamp = get_latest_backup_timestamp(current_save_directory)
-    print(f"DEBUG: Current save timestamp: {current_save_timestamp}")
 
     if current_save_timestamp == last_backup_timestamp:
         if (display_prompt):
             promptEnter("No changes detected since last backup. Backup aborted.")
-        print("DEBUG: No changes detected since last backup. Backup aborted.")
+        # print("DEBUG: No changes detected since last backup. Backup aborted.")
         return
     elif last_backup_timestamp is None or current_save_timestamp > last_backup_timestamp:
         last_backup_timestamp = current_save_timestamp
 
     # this will remove any excess backups if the max backups is set
-    print("DEBUG: Managing backups...")
     manage_backups()
-    print("DEBUG: Backups managed.")
     
     random_string = "_"+generate_random_string()
     save_name = "BackupSave" + random_string
@@ -290,7 +286,7 @@ def auto_save(display_prompt=True):
             destination_file = os.path.join("Characters/"+current_character+"/"+save_name, filename)
             shutil.copy(source_file, destination_file)
 
-    print(f"DEBUG: Backup created at {current_save_timestamp}")
+    # print(f"DEBUG: Backup created at {current_save_timestamp}")
 
 def save_game():
 
@@ -548,7 +544,7 @@ def backup_timer(interval):
 
     # Calculate the interval in seconds
     interval_seconds = interval * 60   # Convert interval to seconds
-    interval_seconds = 5 # debug interval
+    # interval_seconds = 5 # debug interval
 
     next_backup_time = time.time() + interval_seconds  # Schedule the first backup
 
@@ -557,9 +553,7 @@ def backup_timer(interval):
         current_time = time.time()
 
         if current_time >= next_backup_time:
-            print("DEBUG: Auto backup triggered.")
             with backup_lock:
-                print("DEBUG: Auto backup lock acquired.")
                 if not backup_active:  # Double-check if the backup is still active
                     break
                 auto_save(display_prompt=False)

--- a/SaveManager.py
+++ b/SaveManager.py
@@ -2,12 +2,21 @@ import os
 import shutil
 import datetime
 import secrets
+import time
+import threading
 
 import tkinter as tk
 from tkinter import filedialog
 
 save_path = ""
 current_character = ""
+
+auto_backup_option_text = "Start Auto Backup" # Text for the auto backup button
+backup_thread = None # Thread for the auto backup
+backup_active = False # Flag to indicate if the auto backup is active
+backup_lock = threading.Lock() # Define a lock for thread-safe operations, like modifying the backup_active flag
+set_max_backups = False # Flag to indicate if the user has set a maximum number of backups
+max_backups = 100 # Default maximum number of backups
 
 def generate_random_string():
     random_hex = ''.join(secrets.choice('0123456789abcdef') for _ in range(16))
@@ -18,7 +27,8 @@ def get_file_timestamp(filename):
     file_path = "Characters/" + current_character + "/" + filename
     return os.path.getmtime(file_path)
 
-def promptEnter():
+def promptEnter(extra_message=""):
+    print(f"\n\t{extra_message}")
     print("\n\t[ -- Press Enter to continue -- ]")
     input("")
 
@@ -236,20 +246,25 @@ def new_character():
             print("\n\t[ -- Press Enter to continue -- ]")
             input("")
 
-def auto_save():
+def auto_save(display_prompt=True):
 
+    if (display_prompt):
+        user_input= input("\n\tDo you want to back up your current save? [Y/N]: ")
+
+        if (user_input.lower() != "y"):
+            return
+    
+    # this will remove any excess backups if the max backups is set
+    manage_backups()
+    
     print("")
-    save_list = os.listdir("Characters/"+current_character)
-    num_saves = len(save_list)
-    num_saves = str(num_saves)
-    save_name = "BackupSave"+num_saves
     random_string = "_"+generate_random_string()
-    save_name = save_name + random_string
-    os.mkdir("Characters/"+current_character+"/"+save_name)
-
-    user_input= input("\n\tDo you want to back up your current save? [Y/N]: ")
-
-    if (user_input != "Y" and user_input != "y"):
+    save_name = "BackupSave" + random_string
+    try:
+        os.mkdir("Characters/"+current_character+"/"+save_name)
+    except FileExistsError:
+        if (display_prompt):
+            promptEnter(f"The directory {save_name} already exists. Backup aborted.")
         return
 
     for filename in os.listdir(save_path+"/remote/win64_save"):
@@ -421,6 +436,124 @@ def view_saves():
 
     promptEnter()
 
+def auto_backup():
+    global backup_thread, backup_active, auto_backup_option_text, set_max_backups, max_backups
+
+    os.system("cls")
+
+    if backup_active:
+        with backup_lock:
+            backup_active = False
+        if backup_thread is not None:
+            backup_thread.join()
+        auto_backup_option_text = "Start Auto Backup"
+        set_max_backups = False
+        max_backups = 100
+        promptEnter("Auto backup stopped.")
+        return
+    
+    print("Note: Save Data can be around 10mb per save. 10 saves = 100mb. 100 saves = 1gb.")
+    print("Note: Please be aware of the space on your drive.")
+    print("Note: If max backups is enabled, excess backups be culled on next auto backup.")
+    print("================================")
+    print("Auto Backup")
+    print("\t\tEnter how often to make backups, in minutes (1-60)")
+    print("\t\tThen, select if you want to set a maximum number of backups.")
+    print("\t\t0. Choose at any time to cancel the whole process.")
+    print("================================")
+    
+    # Get the interval for the auto backup
+    try:
+        interval = int(input("\n\tChoose backup interval, in minutes (1-60): "))
+    except ValueError:
+        promptEnter(f"Input was not a valid number. Auto backup cancelled.")
+        return
+    
+    # Cancel the auto backup if the interval is 0
+    if interval == 0:
+        promptEnter("Auto backup cancelled.")
+        return
+    
+    # Check if the interval is within the valid range
+    if interval < 1 or interval > 60:
+        promptEnter(f"'{interval}' is not a valid input. Auto backup cancelled.")
+        return
+    
+    user_input = input("\n\tDo you want to set a backup max? (recommended) [Y/N]: ")
+    if user_input == "0":
+        promptEnter("Auto backup cancelled.")
+        return
+    elif (user_input.lower() == "y"):
+        try:
+            user_input = int(input("\n\tEnter the maximum number of backups (10-100): "))
+        except ValueError:
+            promptEnter(f"Input was not a valid number. Auto backup cancelled.")
+            return
+        if user_input == 0:
+            promptEnter("Auto backup cancelled.")
+            return
+        elif user_input < 10 or user_input > 100:
+            promptEnter(f"'{user_input}' is not a valid input. Auto backup cancelled.")
+            return
+        set_max_backups = True
+        max_backups = user_input
+        print(f"\n\tMaximum number of backups set to {max_backups}. Excess will be culled on next auto backup.")
+    else:
+        set_max_backups = False
+        max_backups = 100 # set to 100, just in case
+        print("\n\tMax backups set to unlimited.")
+
+
+    with backup_lock:
+        backup_active = True
+        auto_backup_option_text = f"Stop Auto Backup [set to {interval} minutes]"
+    backup_thread = threading.Thread(target=backup_timer, args=(interval,))
+    backup_thread.start()
+    promptEnter(f"Auto backup started with interval of {interval} minutes.")
+    return
+
+# used in the auto_backup function
+def backup_timer(interval):
+    global backup_active, auto_backup_alert_text
+    elapsed_time = 0
+
+    # Calculate the interval in seconds
+    interval_seconds = interval * 60   # Convert interval to seconds
+    # interval_seconds = 5 # debug interval
+
+    while backup_active:
+        time.sleep(1)  # Thread sleeps for 1 second intervals to avoid busy-waiting
+        with backup_lock:
+            if not backup_active:  # Check if timer should still be running
+                break
+        
+        elapsed_time += 1
+        if elapsed_time >= interval_seconds:
+            # print(f"Auto backup created at {datetime.datetime.now()}") # Debug print statement
+            auto_save(display_prompt=False)
+            elapsed_time = 0  # Reset elapsed time after performing a backup
+
+def manage_backups():
+    if not set_max_backups:
+        return
+
+    backup_dir = os.path.join("Characters", current_character)
+    backups = [d for d in os.listdir(backup_dir) if d.startswith('BackupSave')]
+    backups.sort(key=lambda x: os.path.getmtime(os.path.join(backup_dir, x)))
+    
+    # print(f"Current backups ({len(backups)}): {backups}")  # Debug print
+
+    while len(backups) > (max_backups - 1):
+        oldest_backup = backups.pop(0)
+        path_to_delete = os.path.join(backup_dir, oldest_backup)
+        # print(f"Deleting {path_to_delete}...")  # Debug print
+        shutil.rmtree(path_to_delete)
+
+    # print(f"Backups after deletion ({len(backups)}): {backups}")  # Debug print
+
+
+
+
 def run():
 
     while (True):
@@ -435,6 +568,7 @@ def run():
         print("\t3. Load Game")
         print("\t4. Change Character")
         print("\t5. View Saves")
+        print(f"\t6. {auto_backup_option_text}")
         print("\t9. Quit")
         print("================================")
 
@@ -451,10 +585,29 @@ def run():
             change_character()
         elif (user_input == "5"):
             view_saves()
+        elif (user_input == "6"):
+            auto_backup()
     
     terminate()
 
 def terminate():
+    global backup_active, backup_thread
+    
+    print("Terminating the application. Please wait...")
+    
+    # Inform any running threads that the application is closing
+    # Signal the backup thread to stop, if it's running
+    if backup_active:
+        print("Stopping auto backup...")
+        with backup_lock:  # Ensure thread-safe modification
+            backup_active = False
+            
+        # Wait for the backup thread to finish
+        if backup_thread is not None:
+            backup_thread.join()
+            print("Auto backup stopped.")
+    
+    print("Application terminated. Goodbye!")
     quit()
     
 if __name__ == "__main__":

--- a/SaveManager.py
+++ b/SaveManager.py
@@ -265,8 +265,16 @@ def auto_save(display_prompt=True):
             
         current_save_directory = os.path.join(save_path, 'remote', 'win64_save')
         current_save_timestamp = get_latest_save_timestamp(current_save_directory)
+        # log current and last backup timestamps for debugging
+        # print(f"DEBUG: Current save timestamp is {current_save_timestamp}")
+        # print(f"DEBUG: Last backup timestamp is {last_backup_timestamp}")
 
-        last_backup_timestamp = current_save_timestamp
+        if current_save_timestamp == last_backup_timestamp:
+            if (not display_prompt):
+                print("Save file is already backed up. Backup aborted.") # debug
+                return
+        elif last_backup_timestamp is None or current_save_timestamp > last_backup_timestamp:
+            last_backup_timestamp = current_save_timestamp
 
         # this will remove any excess backups if the max backups is set
         manage_backups()
@@ -285,7 +293,7 @@ def auto_save(display_prompt=True):
                 destination_file = os.path.join("Characters/"+current_character+"/"+save_name, filename)
                 shutil.copy(source_file, destination_file)
 
-    # print(f"DEBUG: Backup created at {current_save_timestamp}")
+        # print(f"DEBUG: Backup created at {current_save_timestamp}")
 
 def save_game():
 
@@ -553,7 +561,7 @@ def backup_timer(interval):
         current_time = time.time()
 
         if current_time >= next_backup_time:
-            print("starting auto backup")
+            # print("starting auto backup") #debug
             # print("DEBUG: start lock 1 at backup_timer()")
             with backup_lock:
                 if not backup_active:  # Double-check if the backup is still active

--- a/SaveManager.py
+++ b/SaveManager.py
@@ -262,7 +262,7 @@ def auto_save(display_prompt=True):
     if current_save_timestamp == last_backup_timestamp:
         if (display_prompt):
             promptEnter("No changes detected since last backup. Backup aborted.")
-        print("DEBUG: No changes detected since last backup. Backup aborted.")
+        # print("DEBUG: No changes detected since last backup. Backup aborted.")
         return
     elif last_backup_timestamp is None or current_save_timestamp > last_backup_timestamp:
         last_backup_timestamp = current_save_timestamp
@@ -284,7 +284,7 @@ def auto_save(display_prompt=True):
             destination_file = os.path.join("Characters/"+current_character+"/"+save_name, filename)
             shutil.copy(source_file, destination_file)
 
-    print(f"DEBUG: Backup created at {current_save_timestamp}")
+    # print(f"DEBUG: Backup created at {current_save_timestamp}")
 
 def save_game():
 
@@ -543,7 +543,7 @@ def backup_timer(interval):
 
     # Calculate the interval in seconds
     interval_seconds = interval * 60   # Convert interval to seconds
-    interval_seconds = 5 # debug interval
+    # interval_seconds = 5 # debug interval
 
     next_backup_time = time.time() + interval_seconds  # Schedule the first backup
 


### PR DESCRIPTION
OVERVIEW:
Added auto-backup
Users can choose to turn auto-backup on, then select a time interval (1-60 minutes).
Optional backup maximum can be enabled, which will cull to a set max backups (10-100)
Utilizes threading to do so.

ADDITIONS:
imported time and threading

6 global variables

auto_backup() function. Takes the user through setting up the auto_backup, then runs backup_timer() on it's own thread.

backup_timer() function. Takes the users chosen interval and loops while backup_active is True. Thread sleeps for 1 second every loop with time.sleep() and increments a counter. Saves once user's threshold is reached and resets that counter. Thread locking happens whenever backup_active is changed to ensure it can can't be changed by more than 1 thread at a time.

manage_backups() function. If the user has set_max_backups to True, manage_backups will gather all the saves starting with 'BackupSave' and pop off and delete backups from oldest to newest, until the total number of backups are the users max_backups - 1. Default max_backups is set to 100 and resets to 100, redudentatly, just in case. Range is from 10 to 100. (save files can reach ~10mb, which noted in the auto backup menu.)

CHANGES: (Made sure to change as little as possible)
promptEnter() now has an extra message that can be passed into it to display extra info or errors. Defaults to an empty string.

auto_save() is slightly retrofitted. It's been given a bool argument, defaulted to true, for displaying the prompt asking if the user if they want to backup their save. manage_backups() added to it. Changed how backup files are named to only be BackupSave + the random string, instead of adding the len of all the files within that directory, as it had all your saves their and was inaccurate and became incompatible with deletions. Added error handling if the random string somehow rolls the same as an existing file. 

run() now has a new option, option 6, which displays an fstring to a global variable, which states "Start Auto Backup" until you enable auto-backup. Then it displays "Stop Auto Backup [set to {global variable} minutes]"

terminate() now more softly closes the program, canceling threads, though completely closing is still safe.

MISC:
Tried my best to preserve the original authors UI style. backup_timer has a commented out line that changes the interval to 5 seconds to debugging. Tested it a bunch, including using it while I play the game, and it seems to work. Sometimes the program can crash when loading a backup, but it's rare.

